### PR TITLE
http proxy interceptor plugin added 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [unreleased]
 
+ * Http Proxy: Added a new plugin type *http-proxy-interceptor* which allows it to rewrite target URIs and headers.
+   This can be used to add security headers to backend calls.
+   **BREAKING CHANGE**: The *getApiSecurityHeaders()* method in the security provider interfaces has been removed since
+   the http-proxy-interceptor is the more generic approach to solve the same problem.
  * LDAP Security Provider: Use the LDAP attributes *displayName* or *givenName* + *sn* as displayName instead of *cn*
  * Portal: The *mashroom-portal-demo-alternative-theme* module uses now *express-react-views* and *TypeScript* to demonstrate
    a type save theme template

--- a/packages/plugin-packages/mashroom-http-proxy/README.md
+++ b/packages/plugin-packages/mashroom-http-proxy/README.md
@@ -84,3 +84,59 @@ export interface MashroomHttpProxyService {
 }
 ```
 
+## Plugin Types
+
+### http-proxy-interceptor
+
+This plugin type can be used to intercept http proxy calls and to add for example authentication headers to backend calls.
+
+To register your custom http-proxy-interceptor plugin add this to _package.json_:
+
+```json
+{
+    "mashroom": {
+        "plugins": [
+            {
+                "name": "My Custom Http Proxy Interceptor",
+                "type": "http-proxy-interceptor",
+                "bootstrap": "./dist/mashroom-bootstrap",
+                "defaultConfig": {
+                   "myProperty": "foo"
+                }
+            }
+        ]
+    }
+}
+```
+
+The bootstrap returns the interceptor:
+
+```js
+// @flow
+
+import type {MashroomHttpProxyInterceptorPluginBootstrapFunction} from '@mashroom/mashroom-http-proxy/type-definitions';
+
+const bootstrap: MashroomHttpProxyInterceptorPluginBootstrapFunction = async (pluginName, pluginConfig, pluginContextHolder) => {
+
+    return new MyInterceptor(/* ... */);
+};
+
+export default bootstrap;
+```
+
+The provider has to implement the following interface:
+
+```js
+interface MashroomHttpProxyInterceptor {
+
+    /**
+     * Intercept a call to given targetUri.
+     * The additionalHeaders contain headers already added by the caller and other MashroomHttpProxyInterceptor plugins.
+     *
+     * Return null or undefined if you don't want to interfere with a call.
+     */
+    intercept(req: ExpressRequest, additionalHeaders: HttpHeaders, targetUri: string): Promise<?MashroomHttpProxyInterceptorResult>;
+}
+```
+
+

--- a/packages/plugin-packages/mashroom-http-proxy/package.json
+++ b/packages/plugin-packages/mashroom-http-proxy/package.json
@@ -16,7 +16,6 @@
         "@babel/cli": "^7.8.4",
         "@mashroom/mashroom": "1.5.2",
         "@mashroom/mashroom-monitoring-metrics-collector": "1.5.2",
-        "@mashroom/mashroom-security": "1.5.2",
         "@mashroom/mashroom-utils": "1.5.2",
         "@types/jest": "^25.2.3",
         "@types/node": "^14.0.1",
@@ -73,6 +72,12 @@
                     "poolMaxSockets": 10,
                     "socketTimeoutMs": 30000
                 }
+            },
+            {
+                "name": "Mashroom Http Proxy Interceptor Loader",
+                "type": "plugin-loader",
+                "bootstrap": "./dist/plugins/loader/mashroom-bootstrap-http-proxy-interceptor-plugin-loader.js",
+                "loads": "http-proxy-interceptor"
             }
         ]
     }

--- a/packages/plugin-packages/mashroom-http-proxy/src/context/global_context.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/src/context/global_context.ts
@@ -1,0 +1,8 @@
+
+import MashroomHttpProxyInterceptorRegistry from '../plugins/MashroomHttpProxyInterceptorRegistry';
+
+const pluginRegistry = new MashroomHttpProxyInterceptorRegistry();
+
+export default {
+    pluginRegistry,
+};

--- a/packages/plugin-packages/mashroom-http-proxy/src/plugins/MashroomHttpProxyInterceptorRegistry.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/src/plugins/MashroomHttpProxyInterceptorRegistry.ts
@@ -1,0 +1,35 @@
+
+import type {MashroomHttpProxyInterceptor} from '../../type-definitions';
+import type {
+    MashroomHttpProxyInterceptorHolder,
+    MashroomHttpProxyInterceptorRegistry as MashroomHttpProxyInterceptorRegistryType,
+} from '../../type-definitions/internal';
+
+export default class MashroomHttpProxyInterceptorRegistry implements MashroomHttpProxyInterceptorRegistryType {
+
+    private _interceptors: Array<MashroomHttpProxyInterceptorHolder>;
+
+    constructor() {
+        this._interceptors = [];
+    }
+
+    register(pluginName: string, interceptor: MashroomHttpProxyInterceptor): void {
+        // Remove existing
+        this.unregister(pluginName);
+
+        this._interceptors.push({
+            pluginName,
+            interceptor,
+        });
+    }
+
+    unregister(pluginName: string): void {
+        this._interceptors = this.interceptors.filter((holder) => holder.pluginName !== pluginName);
+    }
+
+    get interceptors(): Array<MashroomHttpProxyInterceptorHolder> {
+        // @ts-ignore
+        return Object.freeze(this._interceptors);
+    }
+
+}

--- a/packages/plugin-packages/mashroom-http-proxy/src/plugins/loader/MashroomHttpProxyInterceptorPluginLoader.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/src/plugins/loader/MashroomHttpProxyInterceptorPluginLoader.ts
@@ -1,0 +1,43 @@
+
+import type {
+    MashroomPluginLoader,
+    MashroomPlugin,
+    MashroomPluginConfig,
+    MashroomPluginContextHolder,
+    MashroomLogger,
+    MashroomLoggerFactory
+} from '@mashroom/mashroom/type-definitions';
+import type {
+    MashroomHttpProxyInterceptor,
+    MashroomHttpProxyInterceptorPluginBootstrapFunction,
+} from '../../../type-definitions';
+import type {MashroomHttpProxyInterceptorRegistry} from '../../../type-definitions/internal';
+
+export default class MashroomHttpProxyInterceptorPluginLoader implements MashroomPluginLoader {
+
+    private log: MashroomLogger;
+
+    constructor(private registry: MashroomHttpProxyInterceptorRegistry, loggerFactory: MashroomLoggerFactory) {
+        this.log = loggerFactory('mashroom.httpProxy.plugin.loader');
+    }
+
+    get name(): string {
+        return 'Http Proxy Interceptor Plugin Loader';
+    }
+
+    generateMinimumConfig(): MashroomPluginConfig {
+        return {};
+    }
+
+    async load(plugin: MashroomPlugin, config: MashroomPluginConfig, contextHolder: MashroomPluginContextHolder): Promise<void> {
+        const bootstrap: MashroomHttpProxyInterceptorPluginBootstrapFunction = plugin.requireBootstrap();
+        const interceptor: MashroomHttpProxyInterceptor = await bootstrap(plugin.name, config, contextHolder);
+        this.log.info(`Registering http proxy interceptor plugin: ${plugin.name}`);
+        this.registry.register(plugin.name, interceptor);
+    }
+
+    async unload(plugin: MashroomPlugin): Promise<void>  {
+        this.log.info(`Unregistering http proxy interceptor plugin: ${plugin.name}`);
+        this.registry.unregister(plugin.name);
+    }
+}

--- a/packages/plugin-packages/mashroom-http-proxy/src/plugins/loader/mashroom-bootstrap-http-proxy-interceptor-plugin-loader.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/src/plugins/loader/mashroom-bootstrap-http-proxy-interceptor-plugin-loader.ts
@@ -1,0 +1,12 @@
+// @flow
+
+import context from '../../context/global_context';
+import MashroomHttpProxyInterceptorPluginLoader from './MashroomHttpProxyInterceptorPluginLoader';
+
+import type {MashroomPluginLoaderPluginBootstrapFunction} from '@mashroom/mashroom/type-definitions';
+
+const securityProviderLoaderBootstrap: MashroomPluginLoaderPluginBootstrapFunction = async (pluginName, pluginConfig, pluginContextHolder) => {
+    return new MashroomHttpProxyInterceptorPluginLoader(context.pluginRegistry, pluginContextHolder.getPluginContext().loggerFactory);
+};
+
+export default securityProviderLoaderBootstrap;

--- a/packages/plugin-packages/mashroom-http-proxy/src/proxy/MashroomHttpProxyService.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/src/proxy/MashroomHttpProxyService.ts
@@ -130,20 +130,22 @@ export default class MashroomHttpProxyService implements MashroomHttpProxyServic
             try {
                 const result = await interceptor.intercept(req, { ...additionalHeaders, ...addHeaders }, rewrittenTargetUri);
                 if (result?.reject) {
-                    logger.info(`Http proxy call to ${targetUri} reject by interceptor: ${pluginName}`);
+                    logger.info(`Interceptor: '${pluginName}' rejected call to ${targetUri} with reason: ${result.rejectReason || '-'}`);
                     return result;
                 }
                 if (result?.rewrittenTargetUri) {
-                    logger.info(`Http proxy call to ${targetUri} rewritten to ${result.rewrittenTargetUri} by interceptor: ${pluginName}`);
+                    logger.info(`Interceptor: '${pluginName}' rewrote target URI ${targetUri} to ${result.rewrittenTargetUri}`);
                     rewrittenTargetUri = result.rewrittenTargetUri;
                 }
                 if (result?.addHeaders) {
+                    logger.debug(`Interceptor: '${pluginName}' added HTTP headers`, result.addHeaders);
                     addHeaders = {
                         ...addHeaders,
                         ...result.addHeaders,
                     }
                 }
                 if (result?.removeHeaders) {
+                    logger.debug(`Interceptor: '${pluginName}' removed HTTP headers`, result.removeHeaders);
                     removeHeaders = [
                         ...removeHeaders,
                         ...result.removeHeaders,

--- a/packages/plugin-packages/mashroom-http-proxy/src/proxy/mashroom-bootstrap-services.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/src/proxy/mashroom-bootstrap-services.ts
@@ -1,6 +1,7 @@
 
 import MashroomHttpProxyService from './MashroomHttpProxyService';
 import {setPoolConfig} from '../connection_pool';
+import context from '../context/global_context';
 import {startExportPoolMetrics, stopExportPoolMetrics} from '../metrics/connection_pool_metrics';
 
 import type {MashroomServicesPluginBootstrapFunction} from '@mashroom/mashroom/type-definitions';
@@ -14,7 +15,7 @@ const bootstrap: MashroomServicesPluginBootstrapFunction = async (pluginName, pl
     })
 
     const pluginContext = pluginContextHolder.getPluginContext();
-    const service = new MashroomHttpProxyService(forwardMethods, forwardHeaders, socketTimeoutMs, pluginContext.loggerFactory);
+    const service = new MashroomHttpProxyService(forwardMethods, forwardHeaders, socketTimeoutMs, context.pluginRegistry, pluginContext.loggerFactory);
 
     startExportPoolMetrics(pluginContextHolder);
     pluginContext.services.core.pluginService.onUnloadOnce(pluginName, () => {

--- a/packages/plugin-packages/mashroom-http-proxy/test/MashroomHttpProxyService.test.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/test/MashroomHttpProxyService.test.ts
@@ -10,6 +10,7 @@ const createDummyRequest = (method: string, data?: string) => {
     req.method = method;
     req.headers = {
         'accept-language': 'de',
+        'another-header': 'foo',
     };
     req.pluginContext = {
         loggerFactory,
@@ -24,42 +25,22 @@ const createDummyRequest = (method: string, data?: string) => {
     return req;
 };
 
-const createDummyRequestWithSecurity = (method: string, data?: string) => {
-    const req: any = new Readable();
-    req.method = method;
-    req.headers = {
-        'accept-language': 'de',
-    };
-    req.pluginContext = {
-        loggerFactory,
-        services: {
-            security: {
-                service: {
-                    getApiSecurityHeaders() {
-                        return {
-                            'Authorization': 'Bearer XXXXXXXX',
-                        };
-                    },
-                },
-            },
-        },
-    };
-
-    req.push(data);
-    req.push(null);
-
-    return req;
-};
 
 const createDummyResponse = () => {
     const res: any = new Writable();
     res.statusCode = null;
+    res.statusMessage = null;
     res.body = '';
     res.setHeader = (headerName: string, value: any) => {
         console.info('Header: ', headerName, value);
     };
     res.status = res.sendStatus = function(status: any) {
         this.statusCode = status;
+        return {
+            send(message: string) {
+                res.statusMessage = message;
+            }
+        };
     };
     res.write = function(chunk: any) {
         this.body += chunk.toString();
@@ -67,6 +48,10 @@ const createDummyResponse = () => {
     };
 
     return res;
+};
+
+const emptyPluginRegistry: any = {
+    interceptors: [],
 };
 
 describe('MashroomHttpProxyService', () => {
@@ -80,7 +65,7 @@ describe('MashroomHttpProxyService', () => {
             .get('/foo')
             .reply(200, 'test response');
 
-        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, loggerFactory);
+        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, emptyPluginRegistry, loggerFactory);
 
         const req = createDummyRequest('GET');
         const res = createDummyResponse();
@@ -101,7 +86,7 @@ describe('MashroomHttpProxyService', () => {
             .post('/login')
             .reply(200, 'test post response');
 
-        const httpProxyService = new MashroomHttpProxyService(['GET', 'POST'], [], 2000, loggerFactory);
+        const httpProxyService = new MashroomHttpProxyService(['GET', 'POST'], [], 2000, emptyPluginRegistry, loggerFactory);
 
         const req = createDummyRequest('POST', '{ "user": "test }');
         const res = createDummyResponse();
@@ -118,7 +103,7 @@ describe('MashroomHttpProxyService', () => {
             .get('/foo?q=javascript')
             .reply(200, 'test response');
 
-        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, loggerFactory);
+        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, emptyPluginRegistry, loggerFactory);
 
         const req = createDummyRequest('GET');
         req.query = {
@@ -133,7 +118,7 @@ describe('MashroomHttpProxyService', () => {
     });
 
     it('sets the correct status code if the target is not available', async () => {
-        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, loggerFactory);
+        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, emptyPluginRegistry, loggerFactory);
 
         const req = createDummyRequest('GET');
         const res = createDummyResponse();
@@ -150,7 +135,7 @@ describe('MashroomHttpProxyService', () => {
             .socketDelay(3000)
             .reply(200, 'test response');
 
-        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, loggerFactory);
+        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, emptyPluginRegistry, loggerFactory);
 
         const req = createDummyRequest('GET');
         const res = createDummyResponse();
@@ -166,7 +151,7 @@ describe('MashroomHttpProxyService', () => {
             .get('/foo')
             .reply(201, 'resource created');
 
-        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, loggerFactory);
+        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, emptyPluginRegistry, loggerFactory);
 
         const req = createDummyRequest('GET');
         const res = createDummyResponse();
@@ -176,18 +161,48 @@ describe('MashroomHttpProxyService', () => {
         expect(res.statusCode).toBe(201);
     });
 
-    it('adds security headers to the API call',  async () => {
+    it('adds headers from interceptors',  async () => {
         nock('https://www.mashroom-server.com', {
             reqheaders: {
-                'Authorization': 'Bearer XXXXXXXX',
+               'Authorization': 'Bearer XXXXXXXX',
+                'X-Whatever': '123',
             },
         })
             .get('/foo')
             .reply(200, 'test response');
 
-        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, loggerFactory);
+        const pluginRegistry: any = {
+            interceptors: [
+                {
+                    pluginName: 'Interceptor 1',
+                    interceptor: {
+                        intercept() {
+                            return {
+                                addHeaders: {
+                                    'Authorization': 'Bearer XXXXXXXX',
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    pluginName: 'Interceptor 2',
+                    interceptor: {
+                        intercept() {
+                            return {
+                                addHeaders: {
+                                    'X-Whatever': '123',
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+        }
 
-        const req = createDummyRequestWithSecurity('GET');
+        const httpProxyService = new MashroomHttpProxyService(['GET'], [], 2000, pluginRegistry, loggerFactory);
+
+        const req = createDummyRequest('GET');
         const res = createDummyResponse();
 
         await httpProxyService.forward(req, res, 'https://www.mashroom-server.com/foo');
@@ -195,5 +210,99 @@ describe('MashroomHttpProxyService', () => {
         expect(res.body).toBe('test response');
     });
 
+    it('allows interceptors to remove headers',  async () => {
+        nock('https://www.mashroom-server.com', {
+            badheaders: ['another-header']
+        })
+            .get('/foo')
+            .reply(200, 'test response');
+
+        const pluginRegistry: any = {
+            interceptors: [
+                {
+                    pluginName: 'Interceptor 1',
+                    interceptor: {
+                        intercept() {
+                            return {
+                                removeHeaders: ['another-header']
+                            }
+                        }
+                    }
+                }
+            ],
+        }
+
+        const httpProxyService = new MashroomHttpProxyService(['GET'], ['another-header'], 2000, pluginRegistry, loggerFactory);
+
+        const req = createDummyRequest('GET');
+        const res = createDummyResponse();
+
+        await httpProxyService.forward(req, res, 'https://www.mashroom-server.com/foo');
+
+        expect(res.body).toBe('test response');
+    });
+
+    it('allows interceptors to rewrite the target uri',  async () => {
+        nock('https://www.mashroom-server.com')
+            .get('/foo')
+            .reply(200, 'test response');
+
+        const pluginRegistry: any = {
+            interceptors: [
+                {
+                    pluginName: 'Interceptor 1',
+                    interceptor: {
+                        intercept() {
+                            return {
+                                rewrittenTargetUri: 'https://www.mashroom-server.com/foo',
+                            }
+                        }
+                    }
+                }
+            ],
+        }
+
+        const httpProxyService = new MashroomHttpProxyService(['GET'], ['another-header'], 2000, pluginRegistry, loggerFactory);
+
+        const req = createDummyRequest('GET');
+        const res = createDummyResponse();
+
+        await httpProxyService.forward(req, res, '_MASHROOM_SERVER_');
+
+        expect(res.body).toBe('test response');
+    });
+
+    it('allows interceptors to reject calls',  async () => {
+        nock('https://www.mashroom-server.com')
+            .get('/foo')
+            .reply(200, 'test response');
+
+        const pluginRegistry: any = {
+            interceptors: [
+                {
+                    pluginName: 'Interceptor 1',
+                    interceptor: {
+                        intercept() {
+                            return {
+                                reject: true,
+                                rejectStatusCode: 403,
+                                rejectReason: 'Not allowed',
+                            }
+                        }
+                    }
+                }
+            ],
+        }
+
+        const httpProxyService = new MashroomHttpProxyService(['GET'], ['another-header'], 2000, pluginRegistry, loggerFactory);
+
+        const req = createDummyRequest('GET');
+        const res = createDummyResponse();
+
+        await httpProxyService.forward(req, res, 'https://www.mashroom-server.com/foo');
+
+        expect(res.statusCode).toBe(403);
+        expect(res.statusMessage).toBe('Not allowed');
+    });
 });
 

--- a/packages/plugin-packages/mashroom-http-proxy/type-definitions/api.d.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/type-definitions/api.d.ts
@@ -7,7 +7,11 @@ import type {
 } from '@mashroom/mashroom/type-definitions';
 
 export type HttpHeaders = {
-    [name: string]: string;
+    [name: string]: undefined | string | string[];
+}
+
+export type QueryParams = {
+    [key: string]: undefined | string | string[] | {};
 }
 
 export interface MashroomHttpProxyService {
@@ -24,6 +28,8 @@ export interface MashroomHttpProxyService {
 export type MashroomHttpProxyInterceptorResult = {
     addHeaders?: HttpHeaders;
     removeHeaders?: Array<string>;
+    addQueryParams?: QueryParams;
+    removeQueryParams?: Array<string>;
     rewrittenTargetUri?: string;
     reject?: boolean;
     rejectStatusCode?: number;
@@ -33,12 +39,16 @@ export type MashroomHttpProxyInterceptorResult = {
 interface MashroomHttpProxyInterceptor {
 
     /**
-     * Intercept a call to given targetUri.
-     * The additionalHeaders contain headers already added by the caller and other MashroomHttpProxyInterceptor plugins.
+     * Intercept HTTP proxy call to given targetUri.
+     *
+     * The existingHeaders contain the (filtered!) request headers, headers added by the MashroomHttpProxyService client and the ones already added by other interceptors.
+     * The existingQueryParams contain query parameters from the request and the ones already added by other interceptors.
+     *
+     * req is the request that shall be forwarded. DO NOT MANIPULATE IT. Just use it to access req.method and req.pluginContext.
      *
      * Return null or undefined if you don't want to interfere with a call.
      */
-    intercept(req: Readonly<ExpressRequest>, additionalHeaders: Readonly<HttpHeaders>, targetUri: string): Promise<MashroomHttpProxyInterceptorResult | undefined | null>;
+    intercept(targetUri: string, existingHeaders: Readonly<HttpHeaders>, existingQueryParams: Readonly<QueryParams>, req: Readonly<ExpressRequest>): Promise<MashroomHttpProxyInterceptorResult | undefined | null>;
 }
 
 /*

--- a/packages/plugin-packages/mashroom-http-proxy/type-definitions/api.d.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/type-definitions/api.d.ts
@@ -1,5 +1,10 @@
 
-import type {ExpressRequest, ExpressResponse} from '@mashroom/mashroom/type-definitions';
+import type {
+    ExpressRequest,
+    ExpressResponse,
+    MashroomPluginConfig,
+    MashroomPluginContextHolder
+} from '@mashroom/mashroom/type-definitions';
 
 export type HttpHeaders = {
     [name: string]: string;
@@ -15,3 +20,30 @@ export interface MashroomHttpProxyService {
     forward(req: ExpressRequest, res: ExpressResponse, targetUri: string, additionalHeaders?: HttpHeaders): Promise<void>;
 
 }
+
+export type MashroomHttpProxyInterceptorResult = {
+    addHeaders?: HttpHeaders;
+    removeHeaders?: Array<string>;
+    rewrittenTargetUri?: string;
+    reject?: boolean;
+    rejectStatusCode?: number;
+    rejectReason?: string;
+}
+
+interface MashroomHttpProxyInterceptor {
+
+    /**
+     * Intercept a call to given targetUri.
+     * The additionalHeaders contain headers already added by the caller and other MashroomHttpProxyInterceptor plugins.
+     *
+     * Return null or undefined if you don't want to interfere with a call.
+     */
+    intercept(req: Readonly<ExpressRequest>, additionalHeaders: Readonly<HttpHeaders>, targetUri: string): Promise<MashroomHttpProxyInterceptorResult | undefined | null>;
+}
+
+/*
+ * Bootstrap method definition for http-proxy-interceptor plugins
+ */
+export type MashroomHttpProxyInterceptorPluginBootstrapFunction = (pluginName: string, pluginConfig: MashroomPluginConfig, contextHolder: MashroomPluginContextHolder) => Promise<MashroomHttpProxyInterceptor>;
+
+

--- a/packages/plugin-packages/mashroom-http-proxy/type-definitions/index.js
+++ b/packages/plugin-packages/mashroom-http-proxy/type-definitions/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {ExpressRequest, ExpressResponse} from '@mashroom/mashroom/type-definitions';
+import type {ExpressRequest, ExpressResponse, MashroomPluginConfig, MashroomPluginContextHolder} from '@mashroom/mashroom/type-definitions';
 
 export type HttpHeaders = {
     [string]: string,
@@ -16,3 +16,30 @@ export interface MashroomHttpProxyService {
     forward(req: ExpressRequest, res: ExpressResponse, targetUri: string, additionalHeaders?: HttpHeaders): Promise<void>;
 
 }
+
+export type MashroomHttpProxyInterceptorResult = {
+    addHeaders?: HttpHeaders;
+    removeHeaders?: Array<string>;
+    rewrittenTargetUri?: string;
+    reject?: boolean;
+    rejectStatusCode?: number;
+    rejectReason?: string;
+}
+
+interface MashroomHttpProxyInterceptor {
+
+    /**
+     * Intercept a call to given targetUri.
+     * The additionalHeaders contain headers already added by the caller and other MashroomHttpProxyInterceptor plugins.
+     *
+     * Return null or undefined if you don't want to interfere with a call.
+     */
+    intercept(req: ExpressRequest, additionalHeaders: HttpHeaders, targetUri: string): Promise<?MashroomHttpProxyInterceptorResult>;
+}
+
+/*
+ * Bootstrap method definition for http-proxy-interceptor plugins
+ */
+export type MashroomHttpProxyInterceptorPluginBootstrapFunction = (pluginName: string, pluginConfig: MashroomPluginConfig, contextHolder: MashroomPluginContextHolder) => Promise<MashroomHttpProxyInterceptor>;
+
+

--- a/packages/plugin-packages/mashroom-http-proxy/type-definitions/index.js
+++ b/packages/plugin-packages/mashroom-http-proxy/type-definitions/index.js
@@ -3,7 +3,11 @@
 import type {ExpressRequest, ExpressResponse, MashroomPluginConfig, MashroomPluginContextHolder} from '@mashroom/mashroom/type-definitions';
 
 export type HttpHeaders = {
-    [string]: string,
+    [string]: string;
+}
+
+export type QueryParams = {
+    [key: string]: ?string | string[] | {};
 }
 
 export interface MashroomHttpProxyService {
@@ -20,6 +24,8 @@ export interface MashroomHttpProxyService {
 export type MashroomHttpProxyInterceptorResult = {
     addHeaders?: HttpHeaders;
     removeHeaders?: Array<string>;
+    addQueryParams?: QueryParams;
+    removeQueryParams?: Array<string>;
     rewrittenTargetUri?: string;
     reject?: boolean;
     rejectStatusCode?: number;
@@ -29,12 +35,16 @@ export type MashroomHttpProxyInterceptorResult = {
 interface MashroomHttpProxyInterceptor {
 
     /**
-     * Intercept a call to given targetUri.
-     * The additionalHeaders contain headers already added by the caller and other MashroomHttpProxyInterceptor plugins.
+     * Intercept HTTP proxy call to given targetUri.
+     *
+     * The existingHeaders contain the (filtered!) request headers, headers added by the MashroomHttpProxyService client and the ones already added by other interceptors.
+     * The existingQueryParams contain query parameters from the request and the ones already added by other interceptors.
+     *
+     * req is the request that shall be forwarded. DO NOT MANIPULATE IT. Just use it to access req.method and req.pluginContext.
      *
      * Return null or undefined if you don't want to interfere with a call.
      */
-    intercept(req: ExpressRequest, additionalHeaders: HttpHeaders, targetUri: string): Promise<?MashroomHttpProxyInterceptorResult>;
+    intercept(targetUri: string, existingHeaders: HttpHeaders, existingQueryParams: QueryParams, req: ExpressRequest): Promise<?MashroomHttpProxyInterceptorResult>;
 }
 
 /*

--- a/packages/plugin-packages/mashroom-http-proxy/type-definitions/internal.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/type-definitions/internal.ts
@@ -1,5 +1,6 @@
 
 import type {IncomingHttpHeaders} from 'http';
+import type {MashroomHttpProxyInterceptor} from './api';
 
 export interface HttpHeaderFilter {
     filter(headers: IncomingHttpHeaders): void;
@@ -14,4 +15,15 @@ export type PoolStats = {
     activeConnections: number;
     idleConnections: number;
     waitingRequests: number;
+}
+
+export type MashroomHttpProxyInterceptorHolder = {
+    readonly pluginName: string;
+    readonly interceptor: MashroomHttpProxyInterceptor;
+}
+
+export interface MashroomHttpProxyInterceptorRegistry {
+    readonly interceptors: Array<MashroomHttpProxyInterceptorHolder>;
+    register(pluginName: string, interceptor: MashroomHttpProxyInterceptor): void;
+    unregister(pluginName: string): void;
 }

--- a/packages/plugin-packages/mashroom-security-provider-basic-wrapper/src/MashroomBasicWrapperSecurityProvider.ts
+++ b/packages/plugin-packages/mashroom-security-provider-basic-wrapper/src/MashroomBasicWrapperSecurityProvider.ts
@@ -97,14 +97,6 @@ export default class MashroomBasicWrapperSecurityProvider implements MashroomSec
         return null;
     }
 
-    getApiSecurityHeaders(request: ExpressRequest, targetUri: string): any | null | undefined {
-        const targetSecurityProvider = this.getTargetSecurityProvider(request);
-        if (targetSecurityProvider) {
-            return targetSecurityProvider.getApiSecurityHeaders(request, targetUri);
-        }
-        return null;
-    }
-
     private getAuthorizationHeader(request: ExpressRequest): string | undefined {
         return request.headers.authorization;
     }

--- a/packages/plugin-packages/mashroom-security-provider-ldap/src/MashroomLdapSecurityProvider.ts
+++ b/packages/plugin-packages/mashroom-security-provider-ldap/src/MashroomLdapSecurityProvider.ts
@@ -151,10 +151,6 @@ export default class MashroomLdapSecurityProvider implements MashroomSecurityPro
         return request.session[LDAP_AUTH_USER_SESSION_KEY];
     }
 
-    getApiSecurityHeaders(): any | null | undefined {
-        return null;
-    }
-
     private async getUserGroups(user: LdapEntry, logger: MashroomLogger): Promise<Array<string>> {
         if (!this.groupSearchFilter || !this.groupSearchFilter.trim()) {
             return [];

--- a/packages/plugin-packages/mashroom-security-provider-openid-connect/src/security-provider/MashroomOpenIDConnectSecurityProvider.ts
+++ b/packages/plugin-packages/mashroom-security-provider-openid-connect/src/security-provider/MashroomOpenIDConnectSecurityProvider.ts
@@ -184,7 +184,4 @@ export default class MashroomOpenIDConnectSecurityProvider implements MashroomSe
         return user;
     }
 
-    getApiSecurityHeaders(request: ExpressRequest, targetUri: string): any | null | undefined {
-        return null;
-    }
 }

--- a/packages/plugin-packages/mashroom-security-provider-simple/src/MashroomSimpleSecurityProvider.js
+++ b/packages/plugin-packages/mashroom-security-provider-simple/src/MashroomSimpleSecurityProvider.js
@@ -111,10 +111,6 @@ export default class MashroomSimpleSecurityProvider implements MashroomSecurityP
         return request.session[SIMPLE_AUTH_USER_SESSION_KEY];
     }
 
-    getApiSecurityHeaders() {
-        return null;
-    }
-
     _getUserStore(logger: MashroomLogger): UserStore {
         if (this._userStore) {
             return this._userStore;

--- a/packages/plugin-packages/mashroom-security/src/services/MashroomSecurityService.js
+++ b/packages/plugin-packages/mashroom-security/src/services/MashroomSecurityService.js
@@ -62,21 +62,6 @@ export default class MashroomSecurityService implements MashroomSecurityServiceT
         }
     }
 
-    getApiSecurityHeaders(request: ExpressRequest, targetUri: string): ?any {
-        const logger: MashroomLogger = request.pluginContext.loggerFactory('mashroom.security.service');
-
-        const securityProvider = this._getSecurityProvider(logger);
-        if (securityProvider) {
-            try {
-                return securityProvider.getApiSecurityHeaders(request, targetUri);
-            } catch (e) {
-                logger.error('Security provider returned error: ', e);
-            }
-        }
-
-        return undefined;
-    }
-
     isAuthenticated(request: ExpressRequest) {
         return !!this.getUser(request);
     }

--- a/packages/plugin-packages/mashroom-security/type-definitions/api.js
+++ b/packages/plugin-packages/mashroom-security/type-definitions/api.js
@@ -55,10 +55,6 @@ export interface MashroomSecurityService {
      */
     getUser(request: ExpressRequest): ?MashroomSecurityUser;
     /**
-     * Get extra HTTP headers that should be send with backend/API calls to given URI.
-     */
-    getApiSecurityHeaders(request: ExpressRequest, targetUri: string): ?any;
-    /**
      * Checks if user != null
      */
     isAuthenticated(request: ExpressRequest): boolean;
@@ -164,11 +160,6 @@ export interface MashroomSecurityProvider {
      * Get the current user or null if the user is not authenticated
      */
     getUser(request: ExpressRequest): ?MashroomSecurityUser;
-    /**
-     * Get extra HTTP headers that should be send with backend/API calls to given URI.
-     * Can be used to add some extra context or an access token.
-     */
-    getApiSecurityHeaders(request: ExpressRequest, targetUri: string): ?any;
 }
 
 /*

--- a/packages/plugin-packages/mashroom-security/type-definitions/index.d.ts
+++ b/packages/plugin-packages/mashroom-security/type-definitions/index.d.ts
@@ -20,7 +20,7 @@ export type MashroomSecurityPermissions = Array<MashroomSecurityPermission>;
 export type MashroomSecurityUser = {
     readonly username: string;
     readonly displayName: string | null | undefined;
-    readonly email: string | null | undefined;
+    readonly email: string | null | undefined;
     readonly pictureUrl: string | null | undefined;
     readonly roles: MashroomSecurityRoles;
     readonly extraData: any | null | undefined;
@@ -57,11 +57,6 @@ export interface MashroomSecurityService {
      * Get the current user or null if the user is not authenticated
      */
     getUser(request: ExpressRequest): MashroomSecurityUser | null | undefined;
-
-    /**
-     * Get extra HTTP headers that should be send with backend/API calls to given URI.
-     */
-    getApiSecurityHeaders(request: ExpressRequest, targetUri: string): any | null | undefined;
 
     /**
      * Checks if user != null
@@ -226,12 +221,6 @@ export interface MashroomSecurityProvider {
      * Get the current user or null if the user is not authenticated
      */
     getUser(request: ExpressRequest): MashroomSecurityUser | null | undefined;
-
-    /**
-     * Get extra HTTP headers that should be send with backend/API calls to given URI.
-     * Can be used to add some extra context or an access token.
-     */
-    getApiSecurityHeaders(request: ExpressRequest, targetUri: string): any | null | undefined;
 }
 
 /*


### PR DESCRIPTION
Http Proxy: Added a new plugin type **http-proxy-interceptor** which allows it to rewrite target URIs and headers.
This can be used to add security headers to backend calls.

**BREAKING CHANGE**: Removed the *getApiSecurityHeaders()* method in the security provider interface since the http-proxy-interceptor is the more generic approach to solve the same problem.