### PR TITLE
Fixed header filter bug

### DIFF
--- a/packages/plugin-packages/mashroom-http-proxy/src/proxy/HttpHeaderFilter.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/src/proxy/HttpHeaderFilter.ts
@@ -14,7 +14,10 @@ export default class HttpHeaderFilter implements HttpHeaderFilterType {
 
     filter(headers: HttpHeaders): void {
         for (const headerName in headers) {
-            if (headers.hasOwnProperty(headerName) && !this.forwardHeadersRegexes.find((r) =>  r.test(headerName))) {
+            if (headers.hasOwnProperty(headerName) && !this.forwardHeadersRegexes.find((r) => {
+                r.lastIndex = 0;
+                return r.test(headerName);
+            })) {
                 delete headers[headerName];
             }
         }

--- a/packages/plugin-packages/mashroom-http-proxy/test/HttpHeaderFilter.test.ts
+++ b/packages/plugin-packages/mashroom-http-proxy/test/HttpHeaderFilter.test.ts
@@ -26,6 +26,7 @@ describe('HttpHeaderFilter', () => {
             Connection: 'keep-alive',
             cookie: 'dfdF',
             'content-type': 'application/json',
+            'content-size': '42',
             'x-b3-trace-id': 'sdfdfdfd'
         };
 
@@ -37,9 +38,8 @@ describe('HttpHeaderFilter', () => {
             'Accept-Language': 'en-GB,en-US;q=0.9,en;q=0.8,de;q=0.7',
             'cache-control': 'no-cache',
             'content-type': 'application/json',
+            'content-size': '42',
             'x-b3-trace-id': 'sdfdfdfd'
         });
     });
-
-
 });


### PR DESCRIPTION
Old implementation dropps second header of
  content-type: "application/json"
  content-size: 111

As long as test() returns true, lastIndex will not reset — even when testing a different string!