### PR TITLE
don't allow to cache portal pages that contain CSRF token, even if the page is public and the user anonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [unreleased]
 
+ * Portal: Disable the browser caching for all pages if a CSRF token is present, otherwise stale tokens could be used
  * K8S remote app registry: Improved compatibility with Kubernetes 1.20
  * Added the possibility to delay the server shutdown after receiving SIGTERM via environment variable *WAIT_BEFORE_SERVER_CLOSE*,
    which contains the seconds to wait.

--- a/packages/plugin-packages/mashroom-browser-cache/README.md
+++ b/packages/plugin-packages/mashroom-browser-cache/README.md
@@ -49,20 +49,14 @@ The Cache Control service is accessible through _pluginContext.services.browserC
 ```js
 export interface MashroomCacheControlService {
     /**
-     * Add the Cache-Control header based on the settings and authentication status.
-     * The resourceCanContainSensitiveInformation parameter defines if the resource could contain some sensitive user data
-     * and the caching should be disabled if a user is authenticated.
+     * Add the Cache-Control header based on the policy and authentication status.
      */
-    addCacheControlHeader(
-        resourceCanContainSensitiveInformation: boolean,
-        request: Request,
-        response: Response,
-    ): Promise<void>;
+     addCacheControlHeader(cachingPolicy: CachingPolicy, request: Request, response: Response): void;
 
     /**
      * Remove a previously set Cache-Control header
      */
-    removeCacheControlHeader(response: Response): void;
+     removeCacheControlHeader(response: Response): void;
 }
 ```
 

--- a/packages/plugin-packages/mashroom-browser-cache/test/MashroomCacheControlService.test.ts
+++ b/packages/plugin-packages/mashroom-browser-cache/test/MashroomCacheControlService.test.ts
@@ -4,7 +4,7 @@ import MashroomCacheControlService from '../src/MashroomCacheControlService';
 
 describe('MashroomCacheControlService', () => {
 
-    it('sets the Cache-Control header correctly for an unauthenticated user', async () => {
+    it('sets the Cache-Control header correctly for an unauthenticated user', () => {
         const req: any = {
             method: 'GET',
             pluginContext: {
@@ -24,13 +24,13 @@ describe('MashroomCacheControlService', () => {
         };
 
         const cacheControlService = new MashroomCacheControlService(false, false, 1800, loggerFactory);
-        await cacheControlService.addCacheControlHeader(false, req, res);
+        cacheControlService.addCacheControlHeader('ALWAYS', req, res);
 
         expect(cacheControlHeader).toBeTruthy();
         expect(cacheControlHeader).toBe('public, max-age=1800');
     });
 
-    it('sets the Cache-Control header correctly for an authenticated user', async () => {
+    it('sets the Cache-Control header correctly for an authenticated user', () => {
         const req: any = {
             method: 'GET',
             pluginContext: {
@@ -57,13 +57,13 @@ describe('MashroomCacheControlService', () => {
         };
 
         const cacheControlService = new MashroomCacheControlService(false, false, 1800, loggerFactory);
-        await cacheControlService.addCacheControlHeader(false, req, res);
+        cacheControlService.addCacheControlHeader('ALWAYS', req, res);
 
         expect(cacheControlHeader).toBeTruthy();
         expect(cacheControlHeader).toBe('private, max-age=1800');
     });
 
-    it('doesnt set the Cache-Control header for POST requests', async () => {
+    it('doesnt set the Cache-Control header for POST requests', () => {
         const req: any = {
             method: 'POST',
             pluginContext: {
@@ -81,13 +81,13 @@ describe('MashroomCacheControlService', () => {
         };
 
         const cacheControlService = new MashroomCacheControlService(false, false, 1800, loggerFactory);
-        await cacheControlService.addCacheControlHeader(false, req, res);
+        cacheControlService.addCacheControlHeader('ALWAYS', req, res);
 
         expect(cacheControlHeader).toBeFalsy();
     });
 
 
-    it('sets the no-cache header if disabled is true', async () => {
+    it('sets the no-cache header if disabled is true', () => {
         const req: any = {
             method: 'GET',
             pluginContext: {
@@ -105,13 +105,13 @@ describe('MashroomCacheControlService', () => {
         };
 
         const cacheControlService = new MashroomCacheControlService(false, true, 1800, loggerFactory);
-        await cacheControlService.addCacheControlHeader(false, req, res);
+        cacheControlService.addCacheControlHeader('ALWAYS', req, res);
 
         expect(cacheControlHeader).toBeTruthy();
         expect(cacheControlHeader).toBe('no-cache, no-store, max-age=0');
     });
 
-    it('disables browser caching if devMode is true', async () => {
+    it('disables browser caching if devMode is true', () => {
         const req: any = {
             method: 'GET',
             pluginContext: {
@@ -129,13 +129,13 @@ describe('MashroomCacheControlService', () => {
         };
 
         const cacheControlService = new MashroomCacheControlService(true, false, 1800, loggerFactory);
-        await cacheControlService.addCacheControlHeader(false, req, res);
+        cacheControlService.addCacheControlHeader('ALWAYS', req, res);
 
         expect(cacheControlHeader).toBeTruthy();
         expect(cacheControlHeader).toBe('no-cache, no-store, max-age=0');
     });
 
-    it('sets the no-cache header if onlyForAnonymous is true and the user authenticated', async () => {
+    it('sets the no-cache header if policy is ONLY_FOR_ANONYMOUS_USERS and the user authenticated',  () => {
         const req: any = {
             method: 'GET',
             pluginContext: {
@@ -162,12 +162,34 @@ describe('MashroomCacheControlService', () => {
         };
 
         const cacheControlService = new MashroomCacheControlService(false, false, 1800, loggerFactory);
-        await cacheControlService.addCacheControlHeader(true, req, res);
+        cacheControlService.addCacheControlHeader('ONLY_FOR_ANONYMOUS_USERS', req, res);
 
         expect(cacheControlHeader).toBeTruthy();
         expect(cacheControlHeader).toBe('no-cache, no-store, max-age=0');
     });
 
+    it('sets the no-cache header if policy is NEVER', () => {
+        const req: any = {
+            method: 'GET',
+            pluginContext: {
+                loggerFactory,
+            }
+        };
 
+        let cacheControlHeader = null;
+        const res: any = {
+            set: (headerName: string, header: string) => {
+                if (headerName === 'Cache-Control') {
+                    cacheControlHeader = header;
+                }
+            }
+        };
+
+        const cacheControlService = new MashroomCacheControlService(false, false, 1800, loggerFactory);
+        cacheControlService.addCacheControlHeader('NEVER', req, res);
+
+        expect(cacheControlHeader).toBeTruthy();
+        expect(cacheControlHeader).toBe('no-cache, no-store, max-age=0');
+    });
 });
 

--- a/packages/plugin-packages/mashroom-browser-cache/type-definitions/index.d.ts
+++ b/packages/plugin-packages/mashroom-browser-cache/type-definitions/index.d.ts
@@ -7,11 +7,7 @@ export interface MashroomCacheControlService {
     /**
      * Add the Cache-Control header based on the policy and authentication status.
      */
-    addCacheControlHeader(
-        cachingPolicy: CachingPolicy,
-        request: Request,
-        response: Response,
-    ): void;
+    addCacheControlHeader(cachingPolicy: CachingPolicy, request: Request, response: Response): void;
 
     /**
      * Remove a previously set Cache-Control header

--- a/packages/plugin-packages/mashroom-browser-cache/type-definitions/index.d.ts
+++ b/packages/plugin-packages/mashroom-browser-cache/type-definitions/index.d.ts
@@ -1,17 +1,17 @@
 
 import type {Request, Response} from 'express';
 
+export type CachingPolicy = 'ALWAYS' | 'NEVER' | 'ONLY_FOR_ANONYMOUS_USERS';
+
 export interface MashroomCacheControlService {
     /**
-     * Add the Cache-Control header based on the settings and authentication status.
-     * The resourceCanContainSensitiveInformation parameter defines if the resource could contain some sensitive user data
-     * and the caching should be disabled if a user is authenticated.
+     * Add the Cache-Control header based on the policy and authentication status.
      */
     addCacheControlHeader(
-        resourceCanContainSensitiveInformation: boolean,
+        cachingPolicy: CachingPolicy,
         request: Request,
         response: Response,
-    ): Promise<void>;
+    ): void;
 
     /**
      * Remove a previously set Cache-Control header

--- a/packages/plugin-packages/mashroom-browser-cache/type-definitions/index.js
+++ b/packages/plugin-packages/mashroom-browser-cache/type-definitions/index.js
@@ -2,14 +2,13 @@
 
 import type {ExpressRequest, ExpressResponse} from '@mashroom/mashroom/type-definitions';
 
-export interface MashroomCacheControlService {
+export type CachingPolicy = 'ALWAYS' | 'NEVER' | 'ONLY_FOR_ANONYMOUS_USERS';
 
+export interface MashroomCacheControlService {
     /**
-     * Add the Cache-Control header based on the settings and authentication status.
-     * The resourceCanContainSensitiveInformation parameter defines if the resource could contain some sensitive user data
-     * and the caching should be disabled if a user is authenticated.
+     * Add the Cache-Control header based on the policy and authentication status.
      */
-    addCacheControlHeader(resourceCanContainSensitiveInformation: boolean, request: ExpressRequest, response: ExpressResponse): Promise<void>;
+    addCacheControlHeader(cachingPolicy: CachingPolicy, request: ExpressRequest, response: ExpressResponse): void;
 
     /**
      * Remove a previously set Cache-Control header

--- a/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalAppController.ts
+++ b/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalAppController.ts
@@ -212,7 +212,7 @@ export default class PortalAppController {
         const cacheControlService: MashroomCacheControlService = req.pluginContext.services.browserCache && req.pluginContext.services.browserCache.cacheControl;
 
         if (cacheControlService) {
-            await cacheControlService.addCacheControlHeader(false, req, res);
+            cacheControlService.addCacheControlHeader('ALWAYS', req, res);
         }
 
         const resourceUri = `${portalApp.resourcesRootUri}/${resourcePath}`;

--- a/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalPageEnhancementController.ts
+++ b/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalPageEnhancementController.ts
@@ -46,7 +46,7 @@ export default class PortalPageEnhancementController {
         }
 
         if (cacheControlService) {
-            await cacheControlService.addCacheControlHeader(false, req, res);
+            cacheControlService.addCacheControlHeader('ALWAYS', req, res);
         }
 
         const resourceUri = `${plugin.resourcesRootUri}/${resource.path}`;

--- a/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalPageRenderController.ts
+++ b/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalPageRenderController.ts
@@ -236,9 +236,9 @@ export default class PortalPageRenderController {
                 this._portalWebapp.set('views', theme.viewsPath);
 
                 if (cacheControlService) {
-                    // This will disable the browser cache for authenticated users
-                    //  to prevent that back button exposes potential sensitive information
-                    await cacheControlService.addCacheControlHeader(true, req, res);
+                    // Disable the browser cache for authenticated users to prevent that back button exposes potential sensitive information.
+                    // If a CSRF token is prevent disable the caching always because it must not be cached.
+                    cacheControlService.addCacheControlHeader(model.csrfToken ? 'NEVER' : 'ONLY_FOR_ANONYMOUS_USERS' , req, res);
                 }
 
                 res.render('portal', model);

--- a/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalPageRenderController.ts
+++ b/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalPageRenderController.ts
@@ -237,7 +237,7 @@ export default class PortalPageRenderController {
 
                 if (cacheControlService) {
                     // Disable the browser cache for authenticated users to prevent that back button exposes potential sensitive information.
-                    // If a CSRF token is prevent disable the caching always because it must not be cached.
+                    // If a CSRF token is present disable the caching always because it must not be cached.
                     cacheControlService.addCacheControlHeader(model.csrfToken ? 'NEVER' : 'ONLY_FOR_ANONYMOUS_USERS' , req, res);
                 }
 

--- a/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalResourcesController.ts
+++ b/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalResourcesController.ts
@@ -13,7 +13,7 @@ export default class PortalResourcesController {
         res.type('application/javascript');
 
         if (cacheControlService) {
-            await cacheControlService.addCacheControlHeader(false, req, res);
+            cacheControlService.addCacheControlHeader('ALWAYS', req, res);
         }
 
         res.sendFile(portalClientBundle);

--- a/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalThemeController.ts
+++ b/packages/plugin-packages/mashroom-portal/src/backend/controllers/PortalThemeController.ts
@@ -30,7 +30,7 @@ export default class PortalThemeController {
             logger.debug(`Sending theme resource: ${resourceFile}`);
 
             if (cacheControlService) {
-                await cacheControlService.addCacheControlHeader(false, req, res);
+                cacheControlService.addCacheControlHeader('ALWAYS', req, res);
             }
 
             try {

--- a/packages/plugin-packages/mashroom-security-default-login-webapp/package.json
+++ b/packages/plugin-packages/mashroom-security-default-login-webapp/package.json
@@ -21,6 +21,7 @@
         "@mashroom/mashroom": "1.7.5",
         "@mashroom/mashroom-csrf-protection": "1.7.5",
         "@mashroom/mashroom-i18n": "1.7.5",
+        "@mashroom/mashroom-browser-cache": "1.7.5",
         "@mashroom/mashroom-security": "1.7.5",
         "@mashroom/mashroom-vhost-path-mapper": "1.7.5",
         "@types/body-parser": "^1.19.0",
@@ -47,7 +48,8 @@
                 "bootstrap": "./dist/mashroom-bootstrap.js",
                 "requires": [
                     "Mashroom Security Services",
-                    "Mashroom Internationalization Services"
+                    "Mashroom Internationalization Services",
+                    "Mashroom Browser Cache Services"
                 ],
                 "defaultConfig": {
                     "path": "/login",


### PR DESCRIPTION
+ do the same for the login page