### PR TITLE
Dynamic delay for failing remote portal apps using exponential backof…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  * Admin Toolbar: Fixed applying new appConfig after reload
  * Default Login: Improved the style and added another config property *pageTitle* for the title in
    the header (Default is the server name).
+ * Exponential backoff strategy for failing remote apps
 
 ## 2.0.0-alpha.3 (February 7, 2022)
 


### PR DESCRIPTION
…f strategy (1, 2, 4, ..., 1024 seconds)

to avoid filling logs with failing fetches of remote apps currently not running