### PR TITLE
The Portal tries now to resolve the origin App for all console errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [unreleased]
 
+ * Portal: The Portal tries now to resolve the origin App for all console errors sent to the server.
+   The App name and version is appended to the message and added to the log context. See issue #93
  * OpenID Connect Security Provider: If token validation in the callback fails retry authentication instead of just responding with 403
  * LDAP Security Provider: Made username lookup in userToRoleMapping case-insensitive
  * Admin Toolbar: Fixed applying new appConfig after reload


### PR DESCRIPTION
The App name and version is appended to the message and added to the log context.

Tested in Chrome, Firefox, Edge and IE11 